### PR TITLE
Exclude .git when copying jepsen inside docker/control/jepsen.

### DIFF
--- a/docker/up.sh
+++ b/docker/up.sh
@@ -66,7 +66,7 @@ INFO "Copying .. to control/jepsen"
 (
     rm -rf ./control/jepsen
     mkdir ./control/jepsen
-    (cd ..; tar --exclude=./docker -cf - .)  | tar Cxf ./control/jepsen -
+    (cd ..; tar --exclude=./docker --exclude=./.git -cf - .)  | tar Cxf ./control/jepsen -
 )
 
 


### PR DESCRIPTION
This avoids the current git repository from hosting itself (on a nested level).