### PR TITLE
Add default crate version so ``lein test`` runs the dirty read tests

### DIFF
--- a/crate/README.md
+++ b/crate/README.md
@@ -33,6 +33,10 @@ Then inside the ``jepsen-control`` docker container run:
 
 ``CrateDB Version`` can be for example: ``2.1.7-1~jessie_all``
 
+We also have a test defined that runs dirty-read several times and mixes up 
+the operations (some against ``CrateDB`` and some against 
+``Elasticsearch``). This test scenario can be run using `lein test` in the 
+control box/container.
 
 #### Run Individual Tests
 

--- a/crate/src/jepsen/crate/dirty_read.clj
+++ b/crate/src/jepsen/crate/dirty_read.clj
@@ -224,7 +224,7 @@
                                          (str "sr=" (if (:strong-read o)
                                                       "e" "c"))])))
           :os      debian/os
-          :db      (c/db (subs (str (get opts :crate-version)) 1))
+          :db      (c/db (str/trim (str (get opts :crate-version))))
           :client  (es-client opts)
           :checker (checker/compose
                      {:dirty-read (checker)

--- a/crate/src/jepsen/crate/lost_updates.clj
+++ b/crate/src/jepsen/crate/lost_updates.clj
@@ -102,7 +102,7 @@
     (merge tests/noop-test
            {:name    "lost-updates"
             :os      debian/os
-            :db      (c/db (subs (str (get opts :crate-version)) 1))
+            :db      (c/db (str/trim (str (get opts :crate-version))))
             :client  (client)
             :checker (checker/compose
                        {:set  (independent/checker checker/set)

--- a/crate/src/jepsen/crate/runner.clj
+++ b/crate/src/jepsen/crate/runner.clj
@@ -48,7 +48,7 @@
 
    [nil "--crate-version CRATE_VERSION" 
     "CrateDB Version, e.g. 2.0.7-1~jessie_all"
-    :parse-fn keyword
+    :parse-fn str
     :missing  (str "Missing --crate-version CRATE_VERSION")
    ]
   ]

--- a/crate/src/jepsen/crate/version_divergence.clj
+++ b/crate/src/jepsen/crate/version_divergence.clj
@@ -104,7 +104,7 @@
   (merge tests/noop-test
          {:name    "version-divergence"
           :os      debian/os
-          :db      (c/db (subs (str (get opts :crate-version)) 1))
+          :db      (c/db (str/trim (str (get opts :crate-version))))
           :client  (client)
           :checker (checker/compose
                      {:multi    (independent/checker (multiversion-checker))

--- a/crate/test/jepsen/crate_test.clj
+++ b/crate/test/jepsen/crate_test.clj
@@ -58,6 +58,7 @@
                                   #(jepsen/run!
                                      (dirty-read/test
                                        {:es-ops      es-ops
+                                        :crate-version "2.1.8-1~jessie_all"
                                         :concurrency 30
                                         :time-limit 100}))))]
                 [(:name (first ts))


### PR DESCRIPTION
Also, avoid creating a keyword from the crate-version parameter as we convert
it to a string later anyway.