### PR TITLE
fixes flakiness of the dirty ready test

### DIFF
--- a/crate/scripts/dirty-read.sh
+++ b/crate/scripts/dirty-read.sh
@@ -1,3 +1,5 @@
 #! /bin/sh
 
+JAVA_OPTS="$JAVA_OPTS -Des.set.netty.runtime.available.processors=false"
+
 lein run test --test dirty-read --concurrency 30 --tarball $1 --time-limit 100


### PR DESCRIPTION
ensures that the ES client does not try to set the number of processors
when the client initializes. it could be already set at inside the same
JVM which raises an exception.
although this setting is just an upper limit to prevent too much threads
on machines with lot of cores (>32), this is not relevant for our tests
here.
see also https://github.com/netty/netty/issues/6956