### PR TITLE
Collect the stdout log file as well (daemon process redirect stderr there as well)

### DIFF
--- a/crate/src/jepsen/crate/core.clj
+++ b/crate/src/jepsen/crate/core.clj
@@ -357,7 +357,7 @@
 
     db/LogFiles
     (log-files [_ test node]
-      [(str base-dir "/logs/crate.log")])))
+      [stdout-logfile])))
 
 (defmacro with-errors
   "Unified error handling: takes an operation, evaluates body in a try/catch,


### PR DESCRIPTION
We've had some sporadic 255 test failures where one node is not started,
and there is not crate.log file for that problematic node.
Collect the stdout-logfile which also contains the stderr.