### PR TITLE
Disable the column store for the sets table.

### DIFF
--- a/crate/src/jepsen/crate/lost_updates.clj
+++ b/crate/src/jepsen/crate/lost_updates.clj
@@ -45,8 +45,8 @@
             (info node "Creating table sets")
             (j/execute! c
                         ["create table if not exists sets (
-                         id     integer primary key,
-                         elements string)"])
+                         id       integer primary key,
+                         elements string INDEX OFF STORAGE WITH (columnstore = false))"])
             (j/execute! c
                         ["alter table sets
                          set (number_of_replicas = \"0-all\")"]))))


### PR DESCRIPTION
We use a generate method to insert values into the sets table (the elements
column) which can be larger than the 32766 bytes limit the Lucene enforces
per term. Since we only query by id in our test we disable the index on
the elements column so we can insert tha arbitrary large values.